### PR TITLE
Use master.password file and format on freebsd platform

### DIFF
--- a/cmd/localize/main.go
+++ b/cmd/localize/main.go
@@ -76,7 +76,7 @@ func main() {
 	baseIdentity.MergePasswd()
 	baseIdentity.MergeGroup()
 
-	if err := renameio.WriteFile(filepath.Join(*baseDir, "passwd"), baseIdentity.PasswdBytes(), 0644); err != nil {
+	if err := renameio.WriteFile(filepath.Join(*baseDir, base.PasswdDB), baseIdentity.PasswdBytes(), 0644); err != nil {
 		log.Error("Error writing passwd", "error", err)
 		os.Exit(2)
 	}

--- a/pkg/maps/base/base.go
+++ b/pkg/maps/base/base.go
@@ -90,7 +90,7 @@ func (b *Base) loadShells() error {
 // manipulation.  No filtering is done on load, all filtering is
 // handled during patching.
 func (b *Base) loadPasswd() error {
-	pf, err := os.Open(filepath.Join(b.baseDir, "passwd"))
+	pf, err := os.Open(filepath.Join(b.baseDir, PasswdDB))
 	if err != nil {
 		return err
 	}

--- a/pkg/maps/base/netauth.go
+++ b/pkg/maps/base/netauth.go
@@ -2,7 +2,6 @@ package base
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/netauth/netauth/pkg/netauth"
 	"github.com/the-maldridge/shadow"
@@ -133,32 +132,6 @@ func (b *Base) findMembers(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-// MergePasswd removes all entries above the minimum UID and then adds
-// NetAuth entities that were filtered above.
-func (b *Base) MergePasswd() {
-	b.passwd.Del(b.passwd.FilterUID(func(i int) bool {
-		return i >= int(b.minUID)
-	}))
-
-	tmp := make([]*shadow.PasswdEntry, len(b.entities))
-	idx := 0
-	for i := range b.entities {
-		e := shadow.PasswdEntry{
-			Login:    b.entities[i].GetID(),
-			Password: "*",
-			UID:      int(b.entities[i].GetNumber()),
-			GID:      int(b.pgroups[b.entities[i].GetMeta().GetPrimaryGroup()]),
-			Comment:  b.entities[i].GetMeta().GetGECOS(),
-			Home:     filepath.Join(b.baseHome, b.entities[i].GetID()),
-			Shell:    b.shell(b.entities[i].GetMeta().GetShell()),
-		}
-		tmp[idx] = &e
-		idx++
-	}
-
-	b.passwd.Add(tmp)
 }
 
 // MergeGroup removes all group entries above the minimum GID and then

--- a/pkg/maps/base/netauth_freebsd.go
+++ b/pkg/maps/base/netauth_freebsd.go
@@ -1,0 +1,38 @@
+package base
+
+import (
+	"path/filepath"
+
+	"github.com/the-maldridge/shadow"
+)
+
+const (
+	PasswdDB = "master.passwd"
+)
+
+func (b *Base) MergePasswd() {
+	b.passwd.Del(b.passwd.FilterUID(func(i int) bool {
+		return i >= int(b.minUID)
+	}))
+
+	tmp := make([]*shadow.PasswdEntry, len(b.entities))
+	idx := 0
+	for i := range b.entities {
+		e := shadow.PasswdEntry{
+			Login:    b.entities[i].GetID(),
+			Password: "*",
+			UID:      int(b.entities[i].GetNumber()),
+			GID:      int(b.pgroups[b.entities[i].GetMeta().GetPrimaryGroup()]),
+			Class:    "",
+			Change:   "0",
+			Expire:   "0",
+			Comment:  b.entities[i].GetMeta().GetGECOS(),
+			Home:     filepath.Join(b.baseHome, b.entities[i].GetID()),
+			Shell:    b.shell(b.entities[i].GetMeta().GetShell()),
+		}
+		tmp[idx] = &e
+		idx++
+	}
+
+	b.passwd.Add(tmp)
+}

--- a/pkg/maps/base/netauth_linux.go
+++ b/pkg/maps/base/netauth_linux.go
@@ -1,0 +1,37 @@
+package base
+
+import (
+	"path/filepath"
+
+	"github.com/the-maldridge/shadow"
+)
+
+const (
+	PasswdDB = "passwd"
+)
+
+// MergePasswd removes all entries above the minimum UID and then adds
+// NetAuth entities that were filtered above.
+func (b *Base) MergePasswd() {
+	b.passwd.Del(b.passwd.FilterUID(func(i int) bool {
+		return i >= int(b.minUID)
+	}))
+
+	tmp := make([]*shadow.PasswdEntry, len(b.entities))
+	idx := 0
+	for i := range b.entities {
+		e := shadow.PasswdEntry{
+			Login:    b.entities[i].GetID(),
+			Password: "*",
+			UID:      int(b.entities[i].GetNumber()),
+			GID:      int(b.pgroups[b.entities[i].GetMeta().GetPrimaryGroup()]),
+			Comment:  b.entities[i].GetMeta().GetGECOS(),
+			Home:     filepath.Join(b.baseHome, b.entities[i].GetID()),
+			Shell:    b.shell(b.entities[i].GetMeta().GetShell()),
+		}
+		tmp[idx] = &e
+		idx++
+	}
+
+	b.passwd.Add(tmp)
+}


### PR DESCRIPTION
FreeBSD uses slightly different format for it's user database master.passwd(5)
This change will use ${BASE}/master.passwd on freebsd build targets. 
Before merging this, there's another pr to [the-maldrige/shadow #1](https://github.com/the-maldridge/shadow/pull/1) with necessary changes to the format.

I have tested this on two freebsd hosts. 